### PR TITLE
order get 구현, menu도 함께 Response하도록 변경.

### DIFF
--- a/src/main/java/com/koomineat/koomineat/domain/auth/entity/User.java
+++ b/src/main/java/com/koomineat/koomineat/domain/auth/entity/User.java
@@ -1,7 +1,12 @@
 package com.koomineat.koomineat.domain.auth.entity;
 
+import com.koomineat.koomineat.domain.order.entity.Order;
+import com.koomineat.koomineat.domain.order.entity.OrderItem;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 // postgres와 충돌 피하기 위해.
@@ -20,4 +25,14 @@ public class User {
     // UUID.
     @Column(unique = true)
     private String authToken;
+
+    // orders
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Order> orders = new ArrayList<>();
+
+    public void addOrder(Order order) {
+        this.orders.add(order);
+        order.setUser(this);
+    }
 }

--- a/src/main/java/com/koomineat/koomineat/domain/order/controller/OrderController.java
+++ b/src/main/java/com/koomineat/koomineat/domain/order/controller/OrderController.java
@@ -15,6 +15,105 @@ public class OrderController {
     private final OrderService orderService;
 
     public OrderController(OrderService orderService) {this.orderService = orderService;}
+
+    // 단일 get
+    @GetMapping("/{orderId}")
+    public ApiResponse<OrderResponse> getOrder(
+            @PathVariable Long orderId,
+            @CookieValue(name = UserService.COOKIE_NAME, required = false) String authToken
+    )
+    {
+        return ApiResponse.success(orderService.getOrder(authToken, orderId));
+    }
+
+
+    /*
+    예시 response:
+    {
+    "code": "SUCCESS",
+    "message": "요청이 성공적으로 처리되었습니다.",
+    "data": [
+        {
+            "orderId": 11,
+            "status": "FINISHED",
+            "totalPrice": 16700,
+            "orderItemResponses": [
+                {
+                    "menuItemResponse": {
+                        "menuId": 3,
+                        "name": "바닐라 라떼",
+                        "price": 6100
+                    },
+                    "quantity": 2
+                },
+                {
+                    "menuItemResponse": {
+                        "menuId": 6,
+                        "name": "아메리카노",
+                        "price": 4500
+                    },
+                    "quantity": 1
+                }
+            ],
+            "orderType": "PICKUP",
+            "storeResponse": {
+                "storeId": 1,
+                "name": "카페-K",
+                "location": "본부관",
+                "x": 0.0,
+                "y": 0.0
+            }
+        },
+        {
+            "orderId": 12,
+            "status": "FINISHED",
+            "totalPrice": 35000,
+            "orderItemResponses": [
+                {
+                    "menuItemResponse": {
+                        "menuId": 2,
+                        "name": "카페모카",
+                        "price": 5700
+                    },
+                    "quantity": 4
+                },
+                {
+                    "menuItemResponse": {
+                        "menuId": 1,
+                        "name": "카라멜 마키야또",
+                        "price": 6100
+                    },
+                    "quantity": 2
+                }
+            ],
+            "orderType": "PICKUP",
+            "storeResponse": {
+                "storeId": 1,
+                "name": "카페-K",
+                "location": "본부관",
+                "x": 0.0,
+                "y": 0.0
+            }
+        }
+    ]
+}
+     */
+    @GetMapping("/finished")
+    public ApiResponse<List<OrderResponse>> getFinishedOrders(@CookieValue(name = UserService.COOKIE_NAME, required = false) String authToken)
+    {
+        return ApiResponse.success(orderService.getFinishedOrders(authToken));
+    }
+
+    // 해당 Order를 완료 상태로 만든다. (필요 없을수도 있음.)
+    @PatchMapping("/finish/{orderId}")
+    public ApiResponse<OrderResponse> finishOrder(
+            @PathVariable Long orderId,
+            @CookieValue(name = UserService.COOKIE_NAME, required = false) String authToken
+    )
+    {
+        return ApiResponse.success(orderService.finishOrder(authToken, orderId));
+    }
+
     /*
     request 예시:
     {
@@ -51,7 +150,7 @@ response 예시:
     }
 }
 */
-
+    // 주문 진행.
     @PostMapping
     public ApiResponse<OrderResponse> makeOrder(@CookieValue(name = UserService.COOKIE_NAME, required = false) String authToken, @RequestBody OrderRequest orderRequest)
     {

--- a/src/main/java/com/koomineat/koomineat/domain/order/dto/response/OrderItemResponse.java
+++ b/src/main/java/com/koomineat/koomineat/domain/order/dto/response/OrderItemResponse.java
@@ -1,0 +1,26 @@
+package com.koomineat.koomineat.domain.order.dto.response;
+import com.koomineat.koomineat.domain.order.entity.Order;
+import com.koomineat.koomineat.domain.order.entity.OrderItem;
+import com.koomineat.koomineat.domain.store.dto.response.MenuItemResponse;
+import com.koomineat.koomineat.domain.store.dto.response.StoreResponse;
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+@Builder
+
+// response 형태 변경 필요.
+// menu list 전부 보낼지 결정.
+public class OrderItemResponse {
+
+    private MenuItemResponse menuItemResponse;
+    private int quantity;
+
+    public static OrderItemResponse from(OrderItem o) {
+        return OrderItemResponse.builder()
+                .menuItemResponse(MenuItemResponse.from(o.getMenuItem()))
+                .quantity(o.getQuantity())
+                .build();
+    }
+}

--- a/src/main/java/com/koomineat/koomineat/domain/order/dto/response/OrderResponse.java
+++ b/src/main/java/com/koomineat/koomineat/domain/order/dto/response/OrderResponse.java
@@ -1,6 +1,7 @@
 package com.koomineat.koomineat.domain.order.dto.response;
 
 import com.koomineat.koomineat.domain.order.entity.Order;
+import com.koomineat.koomineat.domain.order.entity.OrderItem;
 import com.koomineat.koomineat.domain.order.entity.OrderStatus;
 import com.koomineat.koomineat.domain.order.entity.OrderType;
 import com.koomineat.koomineat.domain.store.dto.response.MenuItemResponse;
@@ -9,6 +10,9 @@ import com.koomineat.koomineat.domain.store.entity.Store;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.awt.*;
+import java.util.List;
 
 @Getter
 @Builder
@@ -21,15 +25,23 @@ public class OrderResponse {
     private OrderStatus status;
 
     private int totalPrice;
+
+    private List<OrderItemResponse> orderItemResponses;
     private OrderType orderType;
 
     private StoreResponse storeResponse;
 
     public static OrderResponse from(Order o) {
+        List<OrderItemResponse> orderItemResponses =  o.getOrderItems()
+                .stream()
+                .map(OrderItemResponse::from)
+                .toList();
+
         return OrderResponse.builder()
                 .orderId(o.getId())
                 .status(o.getStatus())
                 .totalPrice(o.getTotalPrice())
+                .orderItemResponses(orderItemResponses)
                 .orderType(o.getOrderType())
                 .storeResponse(StoreResponse.from(o.getStore()))
                 .build();

--- a/src/main/java/com/koomineat/koomineat/domain/order/entity/Order.java
+++ b/src/main/java/com/koomineat/koomineat/domain/order/entity/Order.java
@@ -8,6 +8,8 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "orders")
@@ -35,6 +37,10 @@ public class Order {
     @Enumerated(EnumType.STRING)
     private OrderType orderType;
 
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<OrderItem> orderItems = new ArrayList<>();
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
@@ -48,4 +54,9 @@ public class Order {
         this.totalPrice += price;
     }
 
+    public void addOrderItem(OrderItem item) {
+        this.orderItems.add(item);
+        item.setOrder(this);
+        this.addPrice(item.getPrice() * item.getQuantity());
+    }
 }

--- a/src/main/java/com/koomineat/koomineat/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/koomineat/koomineat/domain/order/repository/OrderRepository.java
@@ -1,8 +1,12 @@
 package com.koomineat.koomineat.domain.order.repository;
 
 import com.koomineat.koomineat.domain.order.entity.Order;
+import com.koomineat.koomineat.domain.order.entity.OrderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.Optional;
+
+import java.util.List;
+
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
+    List<Order> findByUserIdAndStatus(Long userId, OrderStatus status);
 }

--- a/src/main/java/com/koomineat/koomineat/domain/order/service/OrderService.java
+++ b/src/main/java/com/koomineat/koomineat/domain/order/service/OrderService.java
@@ -5,16 +5,19 @@ import com.koomineat.koomineat.domain.auth.repository.UserRepository;
 import com.koomineat.koomineat.domain.auth.service.UserService;
 import com.koomineat.koomineat.domain.order.dto.request.OrderItemRequest;
 import com.koomineat.koomineat.domain.order.dto.request.OrderRequest;
+import com.koomineat.koomineat.domain.order.dto.response.OrderItemResponse;
 import com.koomineat.koomineat.domain.order.dto.response.OrderResponse;
 import com.koomineat.koomineat.domain.order.entity.Order;
 import com.koomineat.koomineat.domain.order.entity.OrderItem;
 import com.koomineat.koomineat.domain.order.entity.OrderStatus;
+import com.koomineat.koomineat.domain.order.entity.OrderType;
 import com.koomineat.koomineat.domain.order.repository.OrderItemRepository;
 import com.koomineat.koomineat.domain.order.repository.OrderRepository;
 import com.koomineat.koomineat.domain.store.entity.MenuItem;
 import com.koomineat.koomineat.domain.store.repository.MenuItemRepository;
 import com.koomineat.koomineat.domain.store.service.MenuItemService;
 import com.koomineat.koomineat.domain.store.service.StoreService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -30,6 +33,7 @@ public class OrderService {
     private final MenuItemService menuItemService;
     private final StoreService storeService;
 
+    @Transactional
     public OrderResponse makeOrder(String authToken, OrderRequest orderRequest)
     {
         // user.
@@ -37,32 +41,72 @@ public class OrderService {
 
         // Order 생성.
         Order order = Order.builder()
+                // default로 Preparing으로 설정.
                 .status(OrderStatus.PREPARING)
                 .orderType(orderRequest.getOrderType())
-                .user(user)
                 .store(storeService.getStoreById(orderRequest.getStoreId()))
                 .build();
-        order = orderRepository.save(order);
 
         for(OrderItemRequest menu : orderRequest.getMenus())
         {
-            Long menuItemId = menu.getMenuItemId();
-            MenuItem menuItem = menuItemService.getMenuItemById(menuItemId);
+            MenuItem menuItem = menuItemService.getMenuItemById(menu.getMenuItemId());
 
             // orderItem 생성.
             OrderItem orderItem = OrderItem.builder()
                     .price(menuItem.getPrice())
                     .quantity(menu.getQuantity())
-                    .order(order)
                     .menuItem(menuItem)
                     .build();
-            orderItem = orderItemRepository.save(orderItem);
-
-            // order의 price 증가.
-            order.addPrice(orderItem.getPrice());
+            order.addOrderItem(orderItem);
         }
+
+        // 만약 OrderType이 Pickup이라면 바로 Finish.
+        if(order.getOrderType() == OrderType.PICKUP)
+        {
+            order.setStatus(OrderStatus.FINISHED);
+        }
+        else if(order.getOrderType() == OrderType.DELIVERY)
+        {
+            // delivery 객체 생성 및 저장, 초기화.
+        }
+
+        // user list에 order를 추가.
+        user.addOrder(order);
+        order = orderRepository.save(order);
+        System.out.println(user.getOrders());
 
         return OrderResponse.from(order);
     }
 
+    public OrderResponse getOrder(String authToken, Long orderId)
+    {
+        User user = userService.getUserFromAuthToken(authToken);
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new RuntimeException("Order not found"));
+
+        return OrderResponse.from(order);
+    }
+
+    // status가 FINISHED 상태인 것들만 가져온다.
+    public List<OrderResponse> getFinishedOrders(String authToken)
+    {
+        User user = userService.getUserFromAuthToken(authToken);
+        List<Order> finishedOrders =
+                orderRepository.findByUserIdAndStatus(user.getId(), OrderStatus.FINISHED);
+
+        return finishedOrders.stream()
+                .map(OrderResponse::from)
+                .toList();
+    }
+
+    // order를 finished로 만든다.
+    public OrderResponse finishOrder(String authToken, Long orderId)
+    {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new RuntimeException("Order not found"));
+
+        // set order to finished
+        order.setStatus(OrderStatus.FINISHED);
+        return OrderResponse.from(order);
+    }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ✅ 작업 내용
Order 구현 완료. 

API: 
<img width="685" height="856" alt="image" src="https://github.com/user-attachments/assets/a749bd6b-775c-41c4-abb7-26d2ba592e98" />

주문 목록 조회. orders/finished

개별 조회: orders/{order_id}


픽업으로 설정시 FINISHED 상태로 변경됨.

필요 없을 수도 있지만,
orders/finish/{order_id}로 해당 order의 status를 Finish로 만드는 API 추가.